### PR TITLE
Update agent guidance for version bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,4 @@ Always ensure that all checks in the GitHub Actions run successfully. You should
 - **Linter**: Run `npx biome ci .` (or `npx biome check --write` to fix issues) to ensure code style and linting compliance.
 ## Versioning
 - The version number should be defined only once, in `package.json`. The service worker reads the value from there during the build.
+- Always increment the version number in `package.json` every time you make a change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speedometer",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "description": "Minimal PWA speedometer that displays GPS speed. Includes TypeScript script to render PNG icons from SVG using sharp.",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Summary
- require agents to increment the package.json version with every change
- bumped package version accordingly

## Testing
- npm run test *(fails: playwright binary unavailable due to registry access error)*
- npx biome ci .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b2c864b688326a80fa147b01820b6)