### PR TITLE
Restrict workflows to push events

### DIFF
--- a/.github/workflows/biomejs.yml
+++ b/.github/workflows/biomejs.yml
@@ -2,7 +2,6 @@ name: Linter
 
 on:
   push:
-  pull_request:
 
 jobs:
   linter:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   push:
-  pull_request:
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speedometer",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "description": "Minimal PWA speedometer that displays GPS speed. Includes TypeScript script to render PNG icons from SVG using sharp.",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Summary
- update the linter and test workflows to run only on push events
- bump the package version to 0.0.66 to reflect the workflow change

## Testing
- npm run test *(fails: playwright binary unavailable in environment)*
- npx biome ci . *(fails: npm registry access blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b2e468b4483269615c6c912c5b513)